### PR TITLE
Fix Hulk Deployment

### DIFF
--- a/.github/workflows/hulk_deployment.yaml
+++ b/.github/workflows/hulk_deployment.yaml
@@ -1,9 +1,6 @@
 name: Deploy to Hulk
 
 on:
-  create:
-    branches: 
-      - 'qbd_api_release_*'
   push:
     branches: 
       - 'qbd_api_release_*'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow to trigger only on `push` events for branches starting with `qbd_api_release_*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->