### PR TITLE
fix created_at, updated_at null constraint

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -81,6 +81,8 @@ class Expense(models.Model):
                 expense_data_to_append = {
                     'claim_number': expense['claim_number'],
                     'approved_at': expense['approved_at'],
+                    'expense_created_at': expense['expense_created_at'],
+                    'expense_updated_at': expense['expense_updated_at']
                 }
 
             defaults = {
@@ -105,8 +107,6 @@ class Expense(models.Model):
                 'file_ids': expense['file_ids'],
                 'spent_at': expense['spent_at'],
                 'posted_at': expense['posted_at'],
-                'expense_created_at': expense['expense_created_at'],
-                'expense_updated_at': expense['expense_updated_at'],
                 'fund_source': SOURCE_ACCOUNT_MAP[expense['source_account_type']],
                 'verified_at': expense['verified_at'],
                 'custom_properties': expense['custom_properties'],

--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -69,7 +69,7 @@ class Expense(models.Model):
         db_table = 'expenses'
 
     @staticmethod
-    def create_expense_objects(expenses: List[Dict], workspace_id: int, skip_update: bool = True):
+    def create_expense_objects(expenses: List[Dict], workspace_id: int, skip_update: bool = False):
         """
         Bulk create expense objects
         """

--- a/apps/fyle/queue.py
+++ b/apps/fyle/queue.py
@@ -77,8 +77,9 @@ def async_handle_webhook_callback(body: dict, workspace_id: int) -> None:
         workspace = Workspace.objects.get(org_id=org_id)
         async_task('apps.workspaces.tasks.run_import_export', workspace.id)
 
-    elif body.get('action') == 'UPDATED_AFTER_APPROVAL' and body.get('data') and body.get('resource') == 'EXPENSE':
-        org_id = body['data']['org_id']
-        logger.info("| Updating non-exported expenses through webhook | Content: {{WORKSPACE_ID: {} Payload: {}}}".format(workspace_id, body.get('data')))
-        assert_valid_request(workspace_id=workspace_id, org_id=org_id)
-        async_task('apps.fyle.tasks.update_non_exported_expenses', body['data'])
+    """for allowing expense edit, uncomment the below code and relevant test if required in future"""
+    # elif body.get('action') == 'UPDATED_AFTER_APPROVAL' and body.get('data') and body.get('resource') == 'EXPENSE':
+    #     org_id = body['data']['org_id']
+    #     logger.info("| Updating non-exported expenses through webhook | Content: {{WORKSPACE_ID: {} Payload: {}}}".format(workspace_id, body.get('data')))
+    #     assert_valid_request(workspace_id=workspace_id, org_id=org_id)
+    #     async_task('apps.fyle.tasks.update_non_exported_expenses', body['data'])

--- a/tests/test_fyle/fixtures.py
+++ b/tests/test_fyle/fixtures.py
@@ -43,7 +43,7 @@ fixtures = {
             'name': 'Administration'
         },
         'cost_center_id': 23166,
-        'created_at': '2024-05-10T07:52:10.551260+00:00',
+        'created_at': None,
         'creator_user_id': 'usVN2WTtPqE7',
         'currency': 'USD',
         'custom_fields': [
@@ -180,7 +180,7 @@ fixtures = {
         'tax_group': None,
         'tax_group_id': None,
         'travel_classes': [],
-        'updated_at': '2024-06-10T11:41:40.779611+00:00',
+        'updated_at': None,
         'user': {
             'email': 'admin1@fyleforimporrttest.in',
             'full_name': 'Theresa Brown',

--- a/tests/test_fyle/test_tasks.py
+++ b/tests/test_fyle/test_tasks.py
@@ -255,50 +255,51 @@ def test_support_post_date_integration(
     assert journals[0].date.strftime("%m/%d/%Y") == '05/06/2022'
 
 
-# def test_update_non_exported_expenses(db, create_temp_workspace, mocker, api_client):
-#     expense = fixtures['raw_expense']
-#     default_raw_expense = fixtures['default_raw_expense']
-#     org_id = expense['org_id']
-#     payload = {
-#         "resource": "EXPENSE",
-#         "action": 'UPDATED_AFTER_APPROVAL',
-#         "data": expense,
-#         "reason": 'expense update testing',
-#     }
+def test_update_non_exported_expenses(db, create_temp_workspace, mocker, api_client):
+    expense = fixtures['raw_expense']
+    default_raw_expense = fixtures['default_raw_expense']
+    org_id = expense['org_id']
+    payload = {
+        "resource": "EXPENSE",
+        "action": 'UPDATED_AFTER_APPROVAL',
+        "data": expense,
+        "reason": 'expense update testing',
+    }
 
-#     expense_created, _ = Expense.objects.update_or_create(
-#         org_id=org_id,
-#         expense_id='txhJLOSKs1iN',
-#         workspace_id=1,
-#         defaults=default_raw_expense
-#     )
-#     expense_created.exported = False
-#     expense_created.save()
+    expense_created, _ = Expense.objects.update_or_create(
+        org_id=org_id,
+        expense_id='txhJLOSKs1iN',
+        workspace_id=1,
+        defaults=default_raw_expense
+    )
+    expense_created.exported = False
+    expense_created.save()
 
-#     workspace = Workspace.objects.filter(id=1).first()
-#     workspace.org_id = org_id
-#     workspace.save()
+    workspace = Workspace.objects.filter(id=1).first()
+    workspace.org_id = org_id
+    workspace.save()
 
-#     assert expense_created.category == 'Old Category'
+    assert expense_created.category == 'Old Category'
 
-#     update_non_exported_expenses(payload['data'])
+    update_non_exported_expenses(payload['data'])
 
-#     expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
-#     assert expense.category == 'ABN Withholding'
+    expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
+    assert expense.category == 'ABN Withholding'
 
-#     expense.exported = True
-#     expense.category = 'Old Category'
-#     expense.save()
+    expense.exported = True
+    expense.category = 'Old Category'
+    expense.save()
 
-#     update_non_exported_expenses(payload['data'])
-#     expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
-#     assert expense.category == 'Old Category'
+    update_non_exported_expenses(payload['data'])
+    expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
+    assert expense.category == 'Old Category'
 
-#     try:
-#         update_non_exported_expenses(payload['data'])
-#     except ValidationError as e:
-#         assert e.detail[0] == 'Workspace mismatch'
+    try:
+        update_non_exported_expenses(payload['data'])
+    except ValidationError as e:
+        assert e.detail[0] == 'Workspace mismatch'
 
+#     uncomment this while using the webhook callback for edit expense
 #     url = reverse('webhook-callback', kwargs={'workspace_id': 1})
 #     response = api_client.post(url, data=payload, format='json')
 #     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_fyle/test_tasks.py
+++ b/tests/test_fyle/test_tasks.py
@@ -255,54 +255,54 @@ def test_support_post_date_integration(
     assert journals[0].date.strftime("%m/%d/%Y") == '05/06/2022'
 
 
-def test_update_non_exported_expenses(db, create_temp_workspace, mocker, api_client):
-    expense = fixtures['raw_expense']
-    default_raw_expense = fixtures['default_raw_expense']
-    org_id = expense['org_id']
-    payload = {
-        "resource": "EXPENSE",
-        "action": 'UPDATED_AFTER_APPROVAL',
-        "data": expense,
-        "reason": 'expense update testing',
-    }
+# def test_update_non_exported_expenses(db, create_temp_workspace, mocker, api_client):
+#     expense = fixtures['raw_expense']
+#     default_raw_expense = fixtures['default_raw_expense']
+#     org_id = expense['org_id']
+#     payload = {
+#         "resource": "EXPENSE",
+#         "action": 'UPDATED_AFTER_APPROVAL',
+#         "data": expense,
+#         "reason": 'expense update testing',
+#     }
 
-    expense_created, _ = Expense.objects.update_or_create(
-        org_id=org_id,
-        expense_id='txhJLOSKs1iN',
-        workspace_id=1,
-        defaults=default_raw_expense
-    )
-    expense_created.exported = False
-    expense_created.save()
+#     expense_created, _ = Expense.objects.update_or_create(
+#         org_id=org_id,
+#         expense_id='txhJLOSKs1iN',
+#         workspace_id=1,
+#         defaults=default_raw_expense
+#     )
+#     expense_created.exported = False
+#     expense_created.save()
 
-    workspace = Workspace.objects.filter(id=1).first()
-    workspace.org_id = org_id
-    workspace.save()
+#     workspace = Workspace.objects.filter(id=1).first()
+#     workspace.org_id = org_id
+#     workspace.save()
 
-    assert expense_created.category == 'Old Category'
+#     assert expense_created.category == 'Old Category'
 
-    update_non_exported_expenses(payload['data'])
+#     update_non_exported_expenses(payload['data'])
 
-    expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
-    assert expense.category == 'ABN Withholding'
+#     expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
+#     assert expense.category == 'ABN Withholding'
 
-    expense.exported = True
-    expense.category = 'Old Category'
-    expense.save()
+#     expense.exported = True
+#     expense.category = 'Old Category'
+#     expense.save()
 
-    update_non_exported_expenses(payload['data'])
-    expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
-    assert expense.category == 'Old Category'
+#     update_non_exported_expenses(payload['data'])
+#     expense = Expense.objects.get(expense_id='txhJLOSKs1iN', org_id=org_id)
+#     assert expense.category == 'Old Category'
 
-    try:
-        update_non_exported_expenses(payload['data'])
-    except ValidationError as e:
-        assert e.detail[0] == 'Workspace mismatch'
+#     try:
+#         update_non_exported_expenses(payload['data'])
+#     except ValidationError as e:
+#         assert e.detail[0] == 'Workspace mismatch'
 
-    url = reverse('webhook-callback', kwargs={'workspace_id': 1})
-    response = api_client.post(url, data=payload, format='json')
-    assert response.status_code == status.HTTP_200_OK
+#     url = reverse('webhook-callback', kwargs={'workspace_id': 1})
+#     response = api_client.post(url, data=payload, format='json')
+#     assert response.status_code == status.HTTP_200_OK
 
-    url = reverse('webhook-callback', kwargs={'workspace_id': 2})
-    response = api_client.post(url, data=payload, format='json')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+#     url = reverse('webhook-callback', kwargs={'workspace_id': 2})
+#     response = api_client.post(url, data=payload, format='json')
+#     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a default parameter value in expense creation to ensure expected behavior.

- **Tests**
  - Updated test fixtures to use `None` for `created_at` and `updated_at` fields.
  - Disabled specific test functions related to non-exported expenses to address current logic changes.

- **Chores**
  - Commented out the logic for handling updated expenses via webhook for potential future reactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->