### PR TITLE
feat: Move to v1 from v1beta

### DIFF
--- a/apps/fyle/helpers.py
+++ b/apps/fyle/helpers.py
@@ -69,14 +69,14 @@ def upload_iif_to_fyle(file_path: str, workspace_id: int):
     fyle_credentials = FyleCredential.objects.get(workspace_id=workspace_id)
     
     platform = Platform(
-        server_url='{}/platform/v1beta'.format(fyle_credentials.cluster_domain),
+        server_url='{}/platform/v1'.format(fyle_credentials.cluster_domain),
         token_url=settings.FYLE_TOKEN_URI,
         client_id=settings.FYLE_CLIENT_ID,
         client_secret=settings.FYLE_CLIENT_SECRET,
         refresh_token=fyle_credentials.refresh_token,
      )
 
-    user_id = platform.v1beta.spender.my_profile.get()['data']['user']['id']
+    user_id = platform.v1.spender.my_profile.get()['data']['user']['id']
 
     file_payload = {
         'data': {
@@ -87,7 +87,7 @@ def upload_iif_to_fyle(file_path: str, workspace_id: int):
         }
     }
 
-    file = platform.v1beta.admin.files.create_file(file_payload)['data']
+    file = platform.v1.admin.files.create_file(file_payload)['data']
 
     bulk_generate_file_urls_payload = {
         'data': [
@@ -97,14 +97,14 @@ def upload_iif_to_fyle(file_path: str, workspace_id: int):
         ]
     }
 
-    upload_url = platform.v1beta.admin.files.bulk_generate_file_urls(
+    upload_url = platform.v1.admin.files.bulk_generate_file_urls(
         bulk_generate_file_urls_payload
     )['data'][0]['upload_url']
 
     file_data = open(file_path, 'rb')
     file_data = base64.b64encode(file_data.read())
 
-    platform.v1beta.admin.files.upload_file_to_aws(
+    platform.v1.admin.files.upload_file_to_aws(
         content_type='application/vnd.shana.informed.interchange', # Took the content type from Postman
         url=upload_url,
         data=file_data
@@ -123,7 +123,7 @@ def download_iif_file(file_id: str, workspace_id: int):
     fyle_credentials = FyleCredential.objects.get(workspace_id=workspace_id)
     
     platform = Platform(
-        server_url='{}/platform/v1beta'.format(fyle_credentials.cluster_domain),
+        server_url='{}/platform/v1'.format(fyle_credentials.cluster_domain),
         token_url=settings.FYLE_TOKEN_URI,
         client_id=settings.FYLE_CLIENT_ID,
         client_secret=settings.FYLE_CLIENT_SECRET,
@@ -138,7 +138,7 @@ def download_iif_file(file_id: str, workspace_id: int):
         ]
     }
 
-    download_url = platform.v1beta.admin.files.bulk_generate_file_urls(
+    download_url = platform.v1.admin.files.bulk_generate_file_urls(
         bulk_generate_file_urls_payload
     )['data'][0]['download_url']
 

--- a/apps/mappings/connector.py
+++ b/apps/mappings/connector.py
@@ -13,7 +13,7 @@ class PlatformConnector:
         fyle_credentials = FyleCredential.objects.get(workspace_id=workspace_id)
     
         self.platform = Platform(
-            server_url='{}/platform/v1beta'.format(fyle_credentials.cluster_domain),
+            server_url='{}/platform/v1'.format(fyle_credentials.cluster_domain),
             token_url=settings.FYLE_TOKEN_URI,
             client_id=settings.FYLE_CLIENT_ID,
             client_secret=settings.FYLE_CLIENT_SECRET,
@@ -31,7 +31,7 @@ class PlatformConnector:
             'order': 'updated_at.desc',
         }
 
-        generator = self.platform.v1beta.admin.corporate_cards.list_all(query)
+        generator = self.platform.v1.admin.corporate_cards.list_all(query)
 
         for items in generator:
             card_attributes = []
@@ -73,7 +73,7 @@ class PlatformConnector:
             'type': 'eq.SELECT',
             'is_enabled': 'eq.true'
         }
-        custom_field_gen = self.platform.v1beta.admin.expense_fields.list_all(query)
+        custom_field_gen = self.platform.v1.admin.expense_fields.list_all(query)
         if source_type:
             query = QBDMapping.objects.filter(workspace_id=self.workspace_id, attribute_type=source_type)
             existing_source_attributes = query.values_list('source_value', flat=True)
@@ -111,7 +111,7 @@ class PlatformConnector:
         query = {
         'order': 'updated_at.desc'
         }
-        projects_generator = self.platform.v1beta.admin.projects.list_all(query)
+        projects_generator = self.platform.v1.admin.projects.list_all(query)
         existing_projects = QBDMapping.objects.filter(
             workspace_id=self.workspace_id,
             attribute_type=source_type).values_list('source_value', flat=True)
@@ -141,7 +141,7 @@ class PlatformConnector:
         'order': 'updated_at.desc'
         }
         
-        cost_center_generator = self.platform.v1beta.admin.cost_centers.list_all(query)
+        cost_center_generator = self.platform.v1.admin.cost_centers.list_all(query)
         existing_cost_centers = QBDMapping.objects.filter(
             workspace_id=self.workspace_id,
             attribute_type=source_type).values_list('source_value', flat=True)

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -33,7 +33,7 @@ class UserProfileView(generics.RetrieveAPIView):
 
         platform = PlatformConnector(fyle_credentials)
 
-        employee_profile = platform.connection.v1beta.spender.my_profile.get()
+        employee_profile = platform.connection.v1.spender.my_profile.get()
 
         return Response(
             data=employee_profile,

--- a/dummy_commit.sh
+++ b/dummy_commit.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Create a dummy commit with an empty change
-git commit --allow-empty -m "dummy commit" 

--- a/dummy_commit.sh
+++ b/dummy_commit.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Create a dummy commit with an empty change
+git commit --allow-empty -m "dummy commit" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,12 +20,12 @@ gevent==24.11.1
 gunicorn==23.0.0
 
 # Platform SDK
-fyle==0.37.0
+fyle==0.38.0
 
 # Reusable Fyle Packages
 fyle-rest-auth==1.8.2
 fyle-accounting-mappings==1.33.1
-fyle-integrations-platform-connector==1.38.4
+fyle-integrations-platform-connector==1.40.0
 
 # Postgres Dependincies
 psycopg2-binary==2.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,12 +20,12 @@ gevent==24.11.1
 gunicorn==23.0.0
 
 # Platform SDK
-fyle==0.38.0
+fyle==1.0.0
 
 # Reusable Fyle Packages
 fyle-rest-auth==1.8.2
 fyle-accounting-mappings==1.33.1
-fyle-integrations-platform-connector==1.40.0
+fyle-integrations-platform-connector==2.0.0
 
 # Postgres Dependincies
 psycopg2-binary==2.9.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def test_connection(db):
 
     access_token = get_access_token(refresh_token)
     fyle_connection.access_token = access_token
-    user_profile = fyle_connection.v1beta.spender.my_profile.get()['data']
+    user_profile = fyle_connection.v1.spender.my_profile.get()['data']
     user = User(
         password='', last_login=datetime.now(tz=timezone.utc), id=1, email=user_profile['user']['email'],
         user_id=user_profile['user_id'], full_name='', active='t', staff='f', admin='t'
@@ -96,7 +96,7 @@ def default_session_fixture(request):
     patched_3.__enter__()
 
     patched_4 = mock.patch(
-        'fyle.platform.apis.v1beta.spender.MyProfile.get',
+        'fyle.platform.apis.v1.spender.MyProfile.get',
         return_value=fyle_fixtures['get_my_profile']
     )
     patched_4.__enter__()

--- a/tests/test_fyle/test_tasks.py
+++ b/tests/test_fyle/test_tasks.py
@@ -33,7 +33,7 @@ def test_import_reimbursable_expenses(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['reimbursable_expenses']
     )
 
@@ -69,7 +69,7 @@ def test_import_reimbursable_expenses_fatal(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['reimbursable_expenses']
     )
 
@@ -97,7 +97,7 @@ def test_import_reimbursable_expenses_fail(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['reimbursable_expenses']
     )
 
@@ -128,7 +128,7 @@ def test_import_credit_card_expenses(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['credit_card_expenses']
     )
 
@@ -164,7 +164,7 @@ def test_import_credit_card_expenses_failed(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['credit_card_expenses']
     )
 
@@ -193,7 +193,7 @@ def test_import_credit_card_expenses_fatal(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fixtures['credit_card_expenses']
     )
 

--- a/tests/test_fyle/test_view.py
+++ b/tests/test_fyle/test_view.py
@@ -11,11 +11,11 @@ from tests.test_mapping.fixtures import fixture
 @pytest.mark.django_db(databases=['default'])
 def test_sync_fyle_dimension_view(api_client, test_connection, mocker):
     mocker.patch(
-            'fyle.platform.apis.v1beta.admin.corporate_cards.list_all',
+            'fyle.platform.apis.v1.admin.corporate_cards.list_all',
             return_value=fixture['credit_card_sdk']
         )
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.expense_fields.list_all'
+        'fyle.platform.apis.v1.admin.expense_fields.list_all'
     )
     url = reverse(
         'workspaces'

--- a/tests/test_mapping/test_connector.py
+++ b/tests/test_mapping/test_connector.py
@@ -14,7 +14,7 @@ def test_sync_corporate_card(create_temp_workspace,
 
     workspace_id = 1
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.corporate_cards.list_all',
+        'fyle.platform.apis.v1.admin.corporate_cards.list_all',
         return_value=fixture['credit_card_sdk']
     )
     qbd_connection = PlatformConnector(workspace_id=workspace_id)
@@ -35,7 +35,7 @@ def test_sync_projects(create_temp_workspace, add_fyle_credentials, mocker):
         ]}
     ]
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.projects.list_all',
+        'fyle.platform.apis.v1.admin.projects.list_all',
         return_value=mock_response
     )
     qbd_connection = PlatformConnector(workspace_id=workspace_id)
@@ -65,7 +65,7 @@ def test_sync_cost_center(create_temp_workspace, add_fyle_credentials, mocker):
         ]}
     ]
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.cost_centers.list_all',
+        'fyle.platform.apis.v1.admin.cost_centers.list_all',
         return_value=mock_response
     )
     qbd_connection = PlatformConnector(workspace_id=workspace_id)
@@ -95,7 +95,7 @@ def test_sync_custom_field(mocker, api_client, test_connection):
         {'data': [{'field_name': 'field2', 'options': ['option3', 'option4']}]}
     ]
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.expense_fields.list_all',
+        'fyle.platform.apis.v1.admin.expense_fields.list_all',
         return_value=custom_fields_response
     )
 

--- a/tests/test_qbd/test_tasks.py
+++ b/tests/test_qbd/test_tasks.py
@@ -36,22 +36,22 @@ def test_create_bills_iif_file_report(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -102,22 +102,22 @@ def test_create_bills_iif_file_report_fail(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -164,12 +164,12 @@ def test_create_bills_iif_file_report_fatal(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
@@ -214,22 +214,22 @@ def test_create_bills_iif_file_expense(
     * apps.tasks.models.AccountingExport
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -274,22 +274,22 @@ def test_create_credit_card_purchases_iif_file_expense_vendor(
     Test create credit card purchases iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -337,22 +337,22 @@ def test_create_credit_card_purchases_iif_file_expense_employee(
     Test create credit card purchases iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -405,22 +405,22 @@ def test_create_credit_card_purchases_iif_file_expense_fail(
     Test create credit card purchases iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -460,17 +460,17 @@ def test_create_credit_card_purchases_iif_file_expense_fatal(
     Test create credit card purchases iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -507,22 +507,22 @@ def test_create_journals_iif_file_reimbursable_expense(
     Test create journals iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -572,22 +572,22 @@ def test_create_journals_iif_file_ccc_report_vendor(
     Test create journals iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -638,22 +638,22 @@ def test_create_journals_iif_file_ccc_report_employee(
     Test create journals iif file
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -708,22 +708,22 @@ def test_create_journals_iif_file_ccc_report_fail(
     Test create journals iif file Fail
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -766,17 +766,17 @@ def test_create_journals_iif_file_ccc_report_fatal(
     Test create journals iif file Fatal
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -827,22 +827,22 @@ def test_email_failure(
     Test create journals iif file Failed for email failure
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.create_file',
+        'fyle.platform.apis.v1.admin.Files.create_file',
         return_value=fyle_fixtures['create_file']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.upload_file_to_aws',
+        'fyle.platform.apis.v1.admin.Files.upload_file_to_aws',
         return_value=None
     )
 
@@ -871,7 +871,7 @@ def test_email_failure(
 
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['reimbursable_expenses']
     )
     import_reimbursable_expenses(workspace_id, accounting_export)

--- a/tests/test_tasks/test_views.py
+++ b/tests/test_tasks/test_views.py
@@ -103,7 +103,7 @@ def test_accounting_export_download(api_client, test_connection, mocker):
     Test post of workspace
     '''
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Files.bulk_generate_file_urls',
+        'fyle.platform.apis.v1.admin.Files.bulk_generate_file_urls',
         return_value=fyle_fixtures['generate_file_urls']
     )
 

--- a/tests/test_workspaces/test_tasks.py
+++ b/tests/test_workspaces/test_tasks.py
@@ -49,7 +49,7 @@ def test_run_import_export_bill_ccp(
     Test run import export
     """
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
@@ -75,7 +75,7 @@ def test_run_import_export_journal_journal(
     workspace_id = 3
 
     mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Expenses.list_all',
+        'fyle.platform.apis.v1.admin.Expenses.list_all',
         return_value=fyle_fixtures['credit_card_expenses']
     )
 
@@ -108,7 +108,7 @@ def test_async_create_admin_subcriptions(
     add_fyle_credentials
 ):
     mock_api = mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Subscriptions.post',
+        'fyle.platform.apis.v1.admin.Subscriptions.post',
         return_value={}
     )
     workspace_id = 1
@@ -135,7 +135,7 @@ def test_async_create_admin_subcriptions_2(
     add_fyle_credentials
 ):
     mock_api = mocker.patch(
-        'fyle.platform.apis.v1beta.admin.Subscriptions.post',
+        'fyle.platform.apis.v1.admin.Subscriptions.post',
         return_value={}
     )
     workspace_id = 1


### PR DESCRIPTION
### Description
feat: Move to v1 from v1beta

### Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated integration to use the stable Fyle Platform API v1 instead of v1beta across the application.
  - Upgraded dependencies: `fyle` to version 1.0.0 and `fyle-integrations-platform-connector` to version 2.0.0.

- **Tests**
  - Updated test mocks and fixtures to align with the Fyle Platform API v1 endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->